### PR TITLE
Add warning about creating custom components

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ export default CountdownHTML.extend({
   units: countdown.SECONDS
 });
 ```
+WARNING: If you use `ember generate component my-countdown`, make sure to delete the generated template file `components/my-countdown.hbs` or nothing will appear.
 
 Further usage examples for the two components with all optional parameters explored can be seen in the integration tests. Explanation of the parameters is documented in the [countdownjs](https://github.com/mckamey/countdownjs) readme.
 


### PR DESCRIPTION
I couldn't figure out why nothing was showing up, then i realized it's because my component had a default template of `{{yield}}` which does not render the `text` field of the component